### PR TITLE
Fix Discord command tree initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ activity_generating = Game("Generating...")
 
 # Initialize Discord client
 client = Client(intents=Intents.default(), activity=Game("Initializing..."), status=Status.idle)
-command_tree = app_commands.CommandTree(client)
+command_tree = client.tree
 
 # Embed settings and static embeds
 embed_color = Color.dark_embed()


### PR DESCRIPTION
## Summary
- ensure Discord command tree uses client's built-in tree to register slash commands

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689aaf31a2b8832b8bb0421ecc7f847f