### PR TITLE
Refactor to use commands.Bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM python:3.12
-
 WORKDIR /usr/src/app
 
+RUN apt-get update
+RUN apt-get install ffmpeg -y
+
 COPY . .
-
-RUN apt update
-RUN apt install ffmpeg -y
 RUN pip install --no-cache-dir -r requirements.txt
-
 COPY objects.py /usr/local/lib/python3.12/site-packages/fakeyou/
 
 CMD [ "python", "./main.py" ]


### PR DESCRIPTION
## Summary
- replace Client with commands.Bot
- update event handlers and command tree to use bot instance
- use `/` as the command prefix

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689ab3aa8d40832ba32b8d6bd2dcd99e